### PR TITLE
Interceptor must return server response.

### DIFF
--- a/lib/griffin/interceptors/server/newrelic_interceptor.rb
+++ b/lib/griffin/interceptors/server/newrelic_interceptor.rb
@@ -29,9 +29,11 @@ module Griffin
           NewRelic::Agent::Transaction.start(state, :controller, transaction_name: "Controller/#{transaction_name}", request: req)
 
           begin
-            yield
+            resp = yield
             # gRPC alway returns HTTP status code 200
             state.current_transaction.http_response_code = '200'
+
+            resp
           rescue => e
             NewRelic::Agent::Transaction.notice_error(e)
             raise e


### PR DESCRIPTION
When an app uses newrelic_interceptor and payload_interceptor in the same
time, payload_interceptor would raise an error because
newrelic_interceptor passes "200" to the next interceptor(in this case
payload_interceptor) instead of server response.

FYI @cookpad/dev-infra 