### PR TITLE
Use ActiveSupport::ParameterFilter to silence DEPRECATION WARNING on Rails6

### DIFF
--- a/lib/griffin/interceptors/server/filtered_payload_interceptor.rb
+++ b/lib/griffin/interceptors/server/filtered_payload_interceptor.rb
@@ -2,8 +2,8 @@
 
 require 'griffin/interceptors/server/payload_interceptor'
 
-# Check actionpack exists to use ActionDispatch::Http::ParameterFilter
-gem 'actionpack'
+# Check actionpack exists to use ActionDispatch::Http::ParameterFilter if needed
+gem 'actionpack' unless defined?(ActiveSupport::ParameterFilter)
 
 module Griffin
   module Interceptors
@@ -19,7 +19,13 @@ module Griffin
             end
           end
 
-          @parameter_filter = ActionDispatch::Http::ParameterFilter.new(@filters)
+          # ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1.
+          parameter_filter_klass = if defined?(ActiveSupport::ParameterFilter)
+              ActiveSupport::ParameterFilter
+            else
+              ActionDispatch::Http::ParameterFilter
+            end
+          @parameter_filter = parameter_filter_klass.new(@filters)
         end
 
         def server_streamer(call: nil, **)


### PR DESCRIPTION
ref: https://github.com/rails/rails/commit/7f80be29a2655757985b8f70855940f4dc5445cf

To silence DEPRECTION WARNINGs when using the gem with Rails6, I try to use ActiveSupport::ParameterFilter instead of ActionDispatch::Http::ParameterFilter. 

I tested these changes on my projects which are Rails5, and Rails6. 👀 

please review it 🙏 @cookpad/infra 