### PR TITLE
Bump up version: 0.1.6 -> 0.1.7

### DIFF
--- a/lib/griffin/interceptors/version.rb
+++ b/lib/griffin/interceptors/version.rb
@@ -1,5 +1,5 @@
 module Griffin
   module Interceptors
-    VERSION = '0.1.6'.freeze
+    VERSION = '0.1.7'.freeze
   end
 end


### PR DESCRIPTION
The following fixes will be released:
* [Use ActiveSupport::ParameterFilter to silence DEPRECATION WARNING on Rails6 by 9toon · Pull Request #6 · cookpad/griffin-interceptors](https://github.com/cookpad/griffin-interceptors/pull/6)

cc @cookpad/infra @9toon 