### PR TITLE
Clear Raven context, breadcrumbs each request

### DIFF
--- a/lib/griffin/interceptors/server/raven_interceptor.rb
+++ b/lib/griffin/interceptors/server/raven_interceptor.rb
@@ -17,6 +17,9 @@ module Griffin
 
             raise GRPC::Unknown.new('Internal server error')
           end
+        ensure
+          Raven::Context.clear!
+          Raven::BreadcrumbBuffer.clear!
         end
 
         alias_method :server_streamer, :request_response


### PR DESCRIPTION
Sentry's [Ruby Client](https://github.com/getsentry/raven-ruby/) includes two features that record extra error information

- [Contexts](https://docs.sentry.io/clients/ruby/context/)
- [Breadcrumbs](https://docs.sentry.io/clients/ruby/breadcrumbs/)

Note: these features have been available for 4+ years.

These buffers are request specific. Therefore, they must be cleared after every request, or they will accumulate.

In the Rack middleware built into `raven-ruby`, these buffers are cleared after processing a request

https://github.com/getsentry/raven-ruby/blob/d9d41784c3b5888295bf4b013416f132045b22d4/lib/raven/integrations/rack.rb#L63-L67

I've added a similar step to the griffin interceptor for raven.