### PR TITLE
Add request ID to tags for Sentry events

### DIFF
--- a/lib/griffin/interceptors/server/raven_interceptor.rb
+++ b/lib/griffin/interceptors/server/raven_interceptor.rb
@@ -6,7 +6,11 @@ module Griffin
   module Interceptors
     module Server
       class RavenInterceptor < GRPC::ServerInterceptor
-        def request_response(*)
+        def request_response(call: nil, **)
+          if call.metadata['x-request-id']
+            Raven.tags_context(request_id: call.metadata['x-request-id'])
+          end
+
           begin
             yield
           rescue => e


### PR DESCRIPTION
I'd like to tag Sentry events with request ID so that we can correlate those events with our logs.