### PR TITLE
Support to sentry-ruby gem in server interceptor

### DIFF
--- a/lib/griffin/interceptors/server/sentry_interceptor.rb
+++ b/lib/griffin/interceptors/server/sentry_interceptor.rb
@@ -30,12 +30,10 @@ module Griffin
 
               begin
                 response = yield
+              rescue GRPC::BadStatus => e
+                finish_transaction(transaction, e.code)
+                raise e
               rescue => e
-                if e.is_a?(GRPC::BadStatus)
-                  finish_transaction(transaction, e.code)
-                  raise e
-                end
-
                 GRPC.logger.error("Internal server error: #{e}")
                 finish_transaction(transaction, GrpcKit::StatusCodes::INTERNAL)
                 Sentry.capture_exception(e)

--- a/lib/griffin/interceptors/server/sentry_interceptor.rb
+++ b/lib/griffin/interceptors/server/sentry_interceptor.rb
@@ -29,7 +29,7 @@ module Griffin
               end
 
               begin
-                yield
+                response = yield
               rescue => e
                 if e.is_a?(GRPC::BadStatus)
                   finish_transaction(transaction, e.code)
@@ -41,9 +41,11 @@ module Griffin
                 Sentry.capture_exception(e)
 
                 raise GRPC::Unknown.new("Internal server error")
-              ensure
-                finish_transaction(transaction, GrpcKit::StatusCodes::OK)
               end
+
+              finish_transaction(transaction, GrpcKit::StatusCodes::OK)
+
+              response
             end
           end
         end

--- a/lib/griffin/interceptors/server/sentry_interceptor.rb
+++ b/lib/griffin/interceptors/server/sentry_interceptor.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+gem "sentry-ruby"
+
+module Griffin
+  module Interceptors
+    module Server
+      class SentryInterceptor < GRPC::ServerInterceptor
+        TRANSACTION_OP = "griffin"
+
+        def request_response(request: nil, call: nil, method: nil)
+          return yield unless Sentry.initialized?
+
+          Sentry.clone_hub_to_current_thread
+
+          Sentry.with_scope do |scope|
+            Sentry.with_session_tracking do
+              scope.clear_breadcrumbs
+
+              service_name = call.service_name
+              method_name = method.name
+              scope.set_transaction_name("#{service_name}/#{method_name}")
+
+              transaction = start_transaction(call.metadata, scope)
+              scope.set_span(transaction) if transaction
+
+              if call.metadata["x-request-id"]
+                scope.set_tags(request_id: call.metadata["x-request-id"])
+              end
+
+              begin
+                yield
+              rescue => e
+                if e.is_a?(GRPC::BadStatus)
+                  finish_transaction(transaction, e.code)
+                  raise e
+                end
+
+                GRPC.logger.error("Internal server error: #{e}")
+                finish_transaction(transaction, GrpcKit::StatusCodes::INTERNAL)
+                Sentry.capture_exception(e)
+
+                raise GRPC::Unknown.new("Internal server error")
+              ensure
+                finish_transaction(transaction, GrpcKit::StatusCodes::OK)
+              end
+            end
+          end
+        end
+
+        alias_method :server_streamer, :request_response
+        alias_method :client_streamer, :request_response
+        alias_method :bidi_streamer, :request_response
+
+        private
+
+        def start_transaction(metadata, scope)
+          sentry_trace = metadata["grpc-sentry-trace"]
+          options = { name: scope.transaction_name, op: TRANSACTION_OP }
+          transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+          Sentry.start_transaction(transaction: transaction, custom_sampling_context: { metadata: metadata }, **options)
+        end
+
+        def finish_transaction(transaction, status_code)
+          return unless transaction
+
+          transaction.set_http_status(status_code)
+          transaction.finish
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support `sentry-ruby` gem which is the successor of `sentry-raven` gem. 
There are two changes as follows.

- Introduce new interceptor `SentryInterceptor` to support features of `sentry-ruby`: https://github.com/cookpad/griffin-interceptors/commit/6a17b7541c063c49967810d72591d53b54dcbf6f
  - Implementation for Rack was used as a reference: https://github.com/getsentry/sentry-ruby/blob/8c31a6d2ba67924668d94e8b2e072ec32bd4cc2e/sentry-ruby/lib/sentry/rack/capture_exceptions.rb
- Patch RailsExceptionInterceptor to support `sentry-ruby` on it and relax the mandatory requirement of `sentry-raven`: https://github.com/cookpad/griffin-interceptors/commit/91cf122cf2a50ad3b32eedcbecfc33ee9f7b38ac


@cookpad/infra Please review.